### PR TITLE
Fixed log height

### DIFF
--- a/YoutubeDl.Wpf/ViewModels/HomeViewModel.cs
+++ b/YoutubeDl.Wpf/ViewModels/HomeViewModel.cs
@@ -36,6 +36,7 @@ namespace YoutubeDl.Wpf.ViewModels
 
         public ObservableCollection<Preset> Presets { get; } = [];
 
+
         /// <summary>
         /// Gets the output template history.
         /// This collection was first constructed from <see cref="ObservableSettings.OutputTemplateHistory"/> in reverse order.
@@ -74,6 +75,7 @@ namespace YoutubeDl.Wpf.ViewModels
         public ReactiveCommand<Unit, Unit> OpenEditCustomPresetDialogCommand { get; }
         public ReactiveCommand<Unit, Unit> DuplicatePresetCommand { get; }
         public ReactiveCommand<Unit, Unit> DeleteCustomPresetCommand { get; }
+        public ReactiveCommand<Unit, Unit> ClearLogsCommand { get; }
 
         public HomeViewModel(ObservableSettings settings, BackendService backendService, QueuedTextBoxSink queuedTextBoxSink, PresetDialogViewModel presetDialogViewModel, ISnackbarMessageQueue snackbarMessageQueue)
         {
@@ -83,6 +85,7 @@ namespace YoutubeDl.Wpf.ViewModels
             QueuedTextBoxSink = queuedTextBoxSink;
             PresetDialogVM = presetDialogViewModel;
             _snackbarMessageQueue = snackbarMessageQueue;
+
 
             // Tab icon Easter egg.
             const PackIconKind defaultIcon = PackIconKind.Download;
@@ -208,6 +211,7 @@ namespace YoutubeDl.Wpf.ViewModels
             StartDownloadCommand = ReactiveCommand.CreateFromTask<string>(StartDownloadAsync, canRun);
             ListFormatsCommand = ReactiveCommand.CreateFromTask<string>(BackendInstance.ListFormatsAsync, canRun);
             AbortCommand = ReactiveCommand.CreateFromTask(BackendInstance.AbortAsync, canAbort);
+            ClearLogsCommand = ReactiveCommand.Create(ClearLogs);
 
             OpenAddCustomPresetDialogCommand = ReactiveCommand.Create(OpenAddCustomPresetDialog);
             OpenEditCustomPresetDialogCommand = ReactiveCommand.Create(OpenEditCustomPresetDialog, canEditOrDeletePreset);
@@ -392,6 +396,11 @@ namespace YoutubeDl.Wpf.ViewModels
                 UpdateDownloadPathHistory();
 
             return BackendInstance.StartDownloadAsync(link, cancellationToken);
+        }
+
+        private void ClearLogs()
+        {
+            QueuedTextBoxSink.Content = string.Empty;
         }
     }
 }

--- a/YoutubeDl.Wpf/Views/HomeView.xaml
+++ b/YoutubeDl.Wpf/Views/HomeView.xaml
@@ -16,6 +16,7 @@
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 		<Grid.ColumnDefinitions>
@@ -265,14 +266,20 @@
 			</Grid>
 		</ScrollViewer>
 
-		<TextBlock Grid.Row="2"
+		<Button x:Name="clearLogsButton"
+				Grid.Row="2"
+				Margin="8"
+				Style="{StaticResource MaterialDesignOutlinedButton}"
+				Content="_Clear logs"/>
+
+		<TextBlock Grid.Row="3"
                    Margin="8 20 8 8"
                    Style="{StaticResource MaterialDesignHeadline5TextBlock}">
 			Logs
 		</TextBlock>
 
 		<TextBox x:Name="resultTextBox"
-                 Grid.Row="3"
+                 Grid.Row="4"
                  Margin="8"
                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                  TextWrapping="NoWrap"

--- a/YoutubeDl.Wpf/Views/HomeView.xaml
+++ b/YoutubeDl.Wpf/Views/HomeView.xaml
@@ -3,7 +3,7 @@
     x:TypeArguments="viewmodels:HomeViewModel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
     xmlns:reactiveui="http://reactiveui.net"
@@ -11,178 +11,179 @@
     mc:Ignorable="d"
     d:DataContext="{d:DesignInstance Type=viewmodels:HomeViewModel}"
     d:DesignHeight="720" d:DesignWidth="848">
-    <Grid Margin="16">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="1.5*" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
+	<Grid Margin="16">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
 
-        <TextBlock Grid.Row="0"
+		<TextBlock Grid.Row="0"
                    Margin="8 0 8 8"
                    Style="{StaticResource MaterialDesignHeadline5TextBlock}">
-            Start your download
-        </TextBlock>
+			Start your download
+		</TextBlock>
 
-        <ScrollViewer Grid.Row="1"
+		<ScrollViewer Grid.Row="1"
+					  MaxHeight="300"
                       materialDesign:ScrollViewerAssist.IsAutoHideEnabled="True"
                       HorizontalScrollBarVisibility="Auto"
                       VerticalScrollBarVisibility="Auto">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="40" />
-                    <RowDefinition Height="40" />
-                    <RowDefinition Height="40" />
-                    <RowDefinition Height="40" />
-                    <RowDefinition Height="80" />
-                    <RowDefinition Height="40" MaxHeight="40" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="690" />
-                </Grid.ColumnDefinitions>
+			<Grid>
+				<Grid.RowDefinitions>
+					<RowDefinition Height="40" />
+					<RowDefinition Height="40" />
+					<RowDefinition Height="40" />
+					<RowDefinition Height="40" />
+					<RowDefinition Height="80" />
+					<RowDefinition Height="40" MaxHeight="40" />
+					<RowDefinition Height="Auto" />
+				</Grid.RowDefinitions>
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="690" />
+				</Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Row="0"
+				<TextBlock Grid.Row="0"
                            Grid.Column="0"
                            Margin="8"
                            VerticalAlignment="Center"
                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}">
-                    Video link
-                </TextBlock>
-                <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1">
-                    <TextBox x:Name="linkTextBox"
+					Video link
+				</TextBlock>
+				<StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1">
+					<TextBox x:Name="linkTextBox"
                              Margin="4"
                              Width="384"
                              VerticalAlignment="Center"
                              materialDesign:HintAssist.Hint="e.g. https://www.youtube.com/watch?v=b2390GAm4d0"/>
-                    <Button x:Name="downloadButton"
+					<Button x:Name="downloadButton"
                             Margin="4"
                             Style="{StaticResource MaterialDesignOutlinedButton}"/>
-                    <Button x:Name="listFormatsButton"
+					<Button x:Name="listFormatsButton"
                             Margin="4"
                             Style="{StaticResource MaterialDesignOutlinedSecondaryButton}"
                             Content="_List formats"/>
-                    <Button x:Name="abortButton"
+					<Button x:Name="abortButton"
                             Margin="4"
                             Style="{StaticResource MaterialDesignFlatButton}"
                             Foreground="Red"
                             Content="_Abort"/>
-                </StackPanel>
+				</StackPanel>
 
-                <TextBlock Grid.Row="1"
+				<TextBlock Grid.Row="1"
                            Grid.Column="0"
                            Margin="8"
                            VerticalAlignment="Center"
                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}">
-                    Options
-                </TextBlock>
-                <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1">
-                    <TextBlock VerticalAlignment="Center" Margin="4 4 8 4">Preset</TextBlock>
-                    <ComboBox x:Name="presetComboBox"
+					Options
+				</TextBlock>
+				<StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1">
+					<TextBlock VerticalAlignment="Center" Margin="4 4 8 4">Preset</TextBlock>
+					<ComboBox x:Name="presetComboBox"
                               DisplayMemberPath="DisplayName"
                               StaysOpenOnEdit="True"
                               Margin="4"
                               VerticalAlignment="Center">
-                        <ComboBox.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <VirtualizingStackPanel />
-                            </ItemsPanelTemplate>
-                        </ComboBox.ItemsPanel>
-                    </ComboBox>
-                    <Button x:Name="addPresetButton"
+						<ComboBox.ItemsPanel>
+							<ItemsPanelTemplate>
+								<VirtualizingStackPanel />
+							</ItemsPanelTemplate>
+						</ComboBox.ItemsPanel>
+					</ComboBox>
+					<Button x:Name="addPresetButton"
                             Margin="4 4 2 4"
                             Style="{StaticResource MaterialDesignIconForegroundButton}"
                             ToolTip="Add custom preset"
                             VerticalAlignment="Center"
                             Height="32" Width="32">
-                        <materialDesign:PackIcon Kind="Add" Height="20" Width="20" />
-                    </Button>
-                    <Button x:Name="editPresetButton"
+						<materialDesign:PackIcon Kind="Add" Height="20" Width="20" />
+					</Button>
+					<Button x:Name="editPresetButton"
                             Margin="2 4 2 4"
                             Style="{StaticResource MaterialDesignIconForegroundButton}"
                             ToolTip="Edit custom preset"
                             VerticalAlignment="Center"
                             Height="32" Width="32">
-                        <materialDesign:PackIcon Kind="Edit" Height="20" Width="20" />
-                    </Button>
-                    <Button x:Name="duplicatePresetButton"
+						<materialDesign:PackIcon Kind="Edit" Height="20" Width="20" />
+					</Button>
+					<Button x:Name="duplicatePresetButton"
                             Margin="2 4 2 4"
                             Style="{StaticResource MaterialDesignIconForegroundButton}"
                             ToolTip="Duplicate preset"
                             VerticalAlignment="Center"
                             Height="32" Width="32">
-                        <materialDesign:PackIcon Kind="ContentDuplicate" Height="20" Width="20" />
-                    </Button>
-                    <Button x:Name="deletePresetButton"
+						<materialDesign:PackIcon Kind="ContentDuplicate" Height="20" Width="20" />
+					</Button>
+					<Button x:Name="deletePresetButton"
                             Margin="2 4 2 4"
                             Style="{StaticResource MaterialDesignIconForegroundButton}"
                             ToolTip="Delete custom preset"
                             VerticalAlignment="Center"
                             Height="32" Width="32">
-                        <materialDesign:PackIcon Kind="Delete" Height="20" Width="20" />
-                    </Button>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1">
-                    <TextBlock VerticalAlignment="Center" Margin="4 4 8 4">Subtitles</TextBlock>
-                    <CheckBox x:Name="subtitlesDefaultCheckBox"
+						<materialDesign:PackIcon Kind="Delete" Height="20" Width="20" />
+					</Button>
+				</StackPanel>
+				<StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1">
+					<TextBlock VerticalAlignment="Center" Margin="4 4 8 4">Subtitles</TextBlock>
+					<CheckBox x:Name="subtitlesDefaultCheckBox"
                               Style="{StaticResource MaterialDesignFilterChipOutlineCheckBox}"
                               Content="Default" />
-                    <CheckBox x:Name="subtitlesAllLanguagesCheckBox"
+					<CheckBox x:Name="subtitlesAllLanguagesCheckBox"
                               Style="{StaticResource MaterialDesignFilterChipPrimaryOutlineCheckBox}"
                               Content="All languages" />
-                    <CheckBox x:Name="subtitlesAutoGeneratedCheckBox"
+					<CheckBox x:Name="subtitlesAutoGeneratedCheckBox"
                               Style="{StaticResource MaterialDesignFilterChipSecondaryOutlineCheckBox}"
                               Content="Auto-generated" />
-                </StackPanel>
+				</StackPanel>
 
-                <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1">
-                    <ToggleButton x:Name="metadataToggle" Margin="4"/>
-                    <TextBlock VerticalAlignment="Center" Margin="4">Add metadata</TextBlock>
+				<StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1">
+					<ToggleButton x:Name="metadataToggle" Margin="4"/>
+					<TextBlock VerticalAlignment="Center" Margin="4">Add metadata</TextBlock>
 
-                    <ToggleButton x:Name="thumbnailToggle" Margin="8 4 4 4"/>
-                    <TextBlock VerticalAlignment="Center" Margin="4">Download thumbnail</TextBlock>
+					<ToggleButton x:Name="thumbnailToggle" Margin="8 4 4 4"/>
+					<TextBlock VerticalAlignment="Center" Margin="4">Download thumbnail</TextBlock>
 
-                    <ToggleButton x:Name="playlistToggle" Margin="8 4 4 4"/>
-                    <TextBlock VerticalAlignment="Center" Margin="4">Download playlist</TextBlock>
-                    <TextBox x:Name="playlistItemsTextBox"
+					<ToggleButton x:Name="playlistToggle" Margin="8 4 4 4"/>
+					<TextBlock VerticalAlignment="Center" Margin="4">Download playlist</TextBlock>
+					<TextBox x:Name="playlistItemsTextBox"
                              Margin="4"
                              Width="96"
                              VerticalAlignment="Center"
                              materialDesign:HintAssist.Hint="Items (optional)"/>
-                </StackPanel>
+				</StackPanel>
 
-                <Grid Grid.Row="4" Grid.Column="1">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
+				<Grid Grid.Row="4" Grid.Column="1">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="*"/>
+						<RowDefinition Height="*"/>
+					</Grid.RowDefinitions>
 
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="*"/>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="Auto"/>
+					</Grid.ColumnDefinitions>
 
-                    <ToggleButton x:Name="outputTemplateToggle"
+					<ToggleButton x:Name="outputTemplateToggle"
                                   Grid.Row="0"
                                   Grid.Column="0"
                                   Margin="4"/>
 
-                    <TextBlock Grid.Row="0"
+					<TextBlock Grid.Row="0"
                                Grid.Column="1"
                                Margin="4"
                                VerticalAlignment="Center">
-                        Custom output template
-                    </TextBlock>
+						Custom output template
+					</TextBlock>
 
-                    <ComboBox x:Name="outputTemplateComboBox"
+					<ComboBox x:Name="outputTemplateComboBox"
                               Grid.Row="0"
                               Grid.Column="2"
                               Margin="4"
@@ -190,31 +191,31 @@
                               IsReadOnly="False"
                               StaysOpenOnEdit="True"
                               VerticalAlignment="Center">
-                        <ComboBox.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <VirtualizingStackPanel />
-                            </ItemsPanelTemplate>
-                        </ComboBox.ItemsPanel>
-                    </ComboBox>
+						<ComboBox.ItemsPanel>
+							<ItemsPanelTemplate>
+								<VirtualizingStackPanel />
+							</ItemsPanelTemplate>
+						</ComboBox.ItemsPanel>
+					</ComboBox>
 
-                    <Button x:Name="resetOutputTemplateButton"
+					<Button x:Name="resetOutputTemplateButton"
                             Grid.Row="0"
                             Grid.Column="3"
                             Margin="4"
                             Style="{StaticResource MaterialDesignFlatButton}"
                             Content="Reset"/>
 
-                    <ToggleButton x:Name="pathToggle"
+					<ToggleButton x:Name="pathToggle"
                                   Grid.Row="1"
                                   Grid.Column="0"
                                   Margin="4"/>
 
-                    <TextBlock Grid.Row="1"
+					<TextBlock Grid.Row="1"
                                Grid.Column="1"
                                Margin="4"
                                VerticalAlignment="Center">Custom download path</TextBlock>
 
-                    <ComboBox x:Name="pathComboBox"
+					<ComboBox x:Name="pathComboBox"
                               Grid.Row="1"
                               Grid.Column="2"
                               Margin="4"
@@ -222,55 +223,55 @@
                               IsReadOnly="False"
                               StaysOpenOnEdit="True"
                               VerticalAlignment="Center">
-                        <ComboBox.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <VirtualizingStackPanel />
-                            </ItemsPanelTemplate>
-                        </ComboBox.ItemsPanel>
-                    </ComboBox>
+						<ComboBox.ItemsPanel>
+							<ItemsPanelTemplate>
+								<VirtualizingStackPanel />
+							</ItemsPanelTemplate>
+						</ComboBox.ItemsPanel>
+					</ComboBox>
 
-                    <Button x:Name="browseButton"
+					<Button x:Name="browseButton"
                             Grid.Row="1"
                             Grid.Column="3"
                             Margin="4"
                             Style="{StaticResource MaterialDesignFlatButton}"
                             Content="Browse"/>
 
-                    <Button x:Name="openFolderButton"
+					<Button x:Name="openFolderButton"
                             Grid.Row="1"
                             Grid.Column="4"
                             Margin="4"
                             Style="{StaticResource MaterialDesignFlatButton}"
                             Content="Open Folder"/>
-                </Grid>
+				</Grid>
 
-                <TextBlock Grid.Row="5"
+				<TextBlock Grid.Row="5"
                            Grid.Column="0"
                            Margin="8"
                            VerticalAlignment="Center"
                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}">
-                    Arguments
-                </TextBlock>
-                <ItemsControl Grid.Row="5"
+					Arguments
+				</TextBlock>
+				<ItemsControl Grid.Row="5"
                               Grid.RowSpan="2"
                               Grid.Column="1"
                               x:Name="argumentsItemsControl">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel />
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                </ItemsControl>
-            </Grid>
-        </ScrollViewer>
+					<ItemsControl.ItemsPanel>
+						<ItemsPanelTemplate>
+							<WrapPanel />
+						</ItemsPanelTemplate>
+					</ItemsControl.ItemsPanel>
+				</ItemsControl>
+			</Grid>
+		</ScrollViewer>
 
-        <TextBlock Grid.Row="2"
+		<TextBlock Grid.Row="2"
                    Margin="8 20 8 8"
                    Style="{StaticResource MaterialDesignHeadline5TextBlock}">
-            Logs
-        </TextBlock>
+			Logs
+		</TextBlock>
 
-        <TextBox x:Name="resultTextBox"
+		<TextBox x:Name="resultTextBox"
                  Grid.Row="3"
                  Margin="8"
                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
@@ -280,5 +281,5 @@
                  HorizontalScrollBarVisibility="Auto"
                  materialDesign:HintAssist.Hint="Output from backend"
                  FontFamily="pack://application:,,,/Resources/RobotoMono/#Roboto Mono"/>
-    </Grid>
+	</Grid>
 </reactiveui:ReactiveUserControl>

--- a/YoutubeDl.Wpf/Views/HomeView.xaml.cs
+++ b/YoutubeDl.Wpf/Views/HomeView.xaml.cs
@@ -238,6 +238,11 @@ namespace YoutubeDl.Wpf.Views
                     viewModel => viewModel.DeleteCustomPresetCommand,
                     view => view.deletePresetButton)
                     .DisposeWith(disposables);
+
+                this.BindCommand(ViewModel,
+                    viewModel => viewModel.ClearLogsCommand,
+                    view => view.clearLogsButton)
+                    .DisposeWith(disposables);
             });
         }
     }


### PR DESCRIPTION
Stopped the scroll viewer from growing downward by setting a MaxHeight and changed the last row definition to be auto to fill up the new free space.